### PR TITLE
Add deploy to netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ $ npm start
 $ npm run build
 ```
 
+## Deploy
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/thangngoc89/statinamic-theme-lumen)
+
 # Thankyou
 
 - Thanks [Alexandr Shelepenok](http://ashk.io) for created [such an awesome theme](https://github.com/hb-gatsby/gatsby-starter-lumen)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lost": "^6.7.2",
     "moment": "^2.12.0",
     "postcss-import": "^8.0.2",
-    "rucksack-css": "^0.8.5"
+    "rucksack-css": "^0.8.5",
+    "statinamic": "0.9.3"
   }
 }


### PR DESCRIPTION
I am looking to add this template as a featured and deployable Phenomic template [staticgen.com](http://www.staticgen.com/), but it needs a netlify.toml file to do so. 

I added a netlify.toml to save the build command and since I did that I added a deploy button so any user can click deploy to clone a version to their GitHub and see their changes live in production.

Checkout netlify if you are interested. We have an open source plan that is useful for templates like this or open source libraries. https://www.netlify.com/open-source/ 

Try it out here:

<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/statinamic-theme-lumen)

